### PR TITLE
Enhance interlock ML utilities

### DIFF
--- a/interlock_ml/__init__.py
+++ b/interlock_ml/__init__.py
@@ -1,23 +1,64 @@
-from .embedding import Embedder, TfidfEmbedder, BertEmbedder
+from .embedding import (
+    Embedder,
+    TfidfEmbedder,
+    BertEmbedder,
+    TransformerEmbedder,
+    FastTextEmbedder,
+)
 from .clustering import (
     Clusterer,
     KMeansClusterer,
     AgglomerativeClusterer,
     DBSCANClusterer,
     GaussianMixtureClusterer,
+    SpectralClusterer,
+    OPTICSClusterer,
+    AffinityPropagationClusterer,
+    HDBSCANClusterer,
 )
 from .hp_search import search_best_clusterer
 from .pipeline import EmbeddingClusteringPipeline
+from .factory import EmbedderFactory, ClustererFactory
+
+# Register default embedders
+for name, cls in [
+    ("tfidf", TfidfEmbedder),
+    ("bert", BertEmbedder),
+    ("transformer", TransformerEmbedder),
+    ("fasttext", FastTextEmbedder),
+]:
+    EmbedderFactory.register(name, cls)
+
+# Register default clusterers
+for name, cls in [
+    ("kmeans", KMeansClusterer),
+    ("agglomerative", AgglomerativeClusterer),
+    ("dbscan", DBSCANClusterer),
+    ("gmm", GaussianMixtureClusterer),
+    ("spectral", SpectralClusterer),
+    ("optics", OPTICSClusterer),
+    ("affinity", AffinityPropagationClusterer),
+    ("hdbscan", HDBSCANClusterer),
+]:
+    ClustererFactory.register(name, cls)
 
 __all__ = [
     "Embedder",
     "TfidfEmbedder",
     "BertEmbedder",
+    "TransformerEmbedder",
+    "FastTextEmbedder",
     "Clusterer",
     "KMeansClusterer",
     "AgglomerativeClusterer",
     "DBSCANClusterer",
     "GaussianMixtureClusterer",
+    "SpectralClusterer",
+    "OPTICSClusterer",
+    "AffinityPropagationClusterer",
+    "HDBSCANClusterer",
+    "EmbedderFactory",
+    "ClustererFactory",
     "search_best_clusterer",
     "EmbeddingClusteringPipeline",
 ]

--- a/interlock_ml/clustering.py
+++ b/interlock_ml/clustering.py
@@ -15,6 +15,7 @@ class Clusterer(ABC):
 class KMeansClusterer(Clusterer):
     def __init__(self, n_clusters: int = 8, random_state: int | None = None):
         from sklearn.cluster import KMeans
+
         self.model = KMeans(n_clusters=n_clusters, random_state=random_state)
 
     def fit_predict(self, X: np.ndarray) -> np.ndarray:
@@ -24,6 +25,7 @@ class KMeansClusterer(Clusterer):
 class AgglomerativeClusterer(Clusterer):
     def __init__(self, n_clusters: int = 8, linkage: str = "ward"):
         from sklearn.cluster import AgglomerativeClustering
+
         self.model = AgglomerativeClustering(n_clusters=n_clusters, linkage=linkage)
 
     def fit_predict(self, X: np.ndarray) -> np.ndarray:
@@ -33,6 +35,7 @@ class AgglomerativeClusterer(Clusterer):
 class DBSCANClusterer(Clusterer):
     def __init__(self, eps: float = 0.5, min_samples: int = 5):
         from sklearn.cluster import DBSCAN
+
         self.model = DBSCAN(eps=eps, min_samples=min_samples)
 
     def fit_predict(self, X: np.ndarray) -> np.ndarray:
@@ -40,9 +43,76 @@ class DBSCANClusterer(Clusterer):
 
 
 class GaussianMixtureClusterer(Clusterer):
-    def __init__(self, n_components: int = 8, covariance_type: str = "full", random_state: int | None = None):
+    def __init__(
+        self,
+        n_components: int = 8,
+        covariance_type: str = "full",
+        random_state: int | None = None,
+    ):
         from sklearn.mixture import GaussianMixture
-        self.model = GaussianMixture(n_components=n_components, covariance_type=covariance_type, random_state=random_state)
+
+        self.model = GaussianMixture(
+            n_components=n_components,
+            covariance_type=covariance_type,
+            random_state=random_state,
+        )
+
+    def fit_predict(self, X: np.ndarray) -> np.ndarray:
+        return self.model.fit_predict(X)
+
+
+class SpectralClusterer(Clusterer):
+    """Cluster data using Spectral Clustering."""
+
+    def __init__(self, n_clusters: int = 8, random_state: int | None = None):
+        from sklearn.cluster import SpectralClustering
+
+        self.model = SpectralClustering(
+            n_clusters=n_clusters, random_state=random_state, assign_labels="kmeans"
+        )
+
+    def fit_predict(self, X: np.ndarray) -> np.ndarray:
+        return self.model.fit_predict(X)
+
+
+class OPTICSClusterer(Clusterer):
+    """Cluster data using OPTICS."""
+
+    def __init__(
+        self,
+        min_samples: int = 5,
+        xi: float = 0.05,
+        min_cluster_size: int | None = None,
+    ):
+        from sklearn.cluster import OPTICS
+
+        self.model = OPTICS(
+            min_samples=min_samples, xi=xi, min_cluster_size=min_cluster_size
+        )
+
+    def fit_predict(self, X: np.ndarray) -> np.ndarray:
+        return self.model.fit_predict(X)
+
+
+class AffinityPropagationClusterer(Clusterer):
+    """Cluster data using Affinity Propagation."""
+
+    def __init__(self, damping: float = 0.5, preference: float | None = None):
+        from sklearn.cluster import AffinityPropagation
+
+        self.model = AffinityPropagation(damping=damping, preference=preference)
+
+    def fit_predict(self, X: np.ndarray) -> np.ndarray:
+        return self.model.fit_predict(X)
+
+
+class HDBSCANClusterer(Clusterer):
+    """Cluster data using HDBSCAN. Requires the ``hdbscan`` package."""
+
+    def __init__(self, min_cluster_size: int = 5):
+        from hdbscan import HDBSCAN
+
+        self.model = HDBSCAN(min_cluster_size=min_cluster_size)
 
     def fit_predict(self, X: np.ndarray) -> np.ndarray:
         return self.model.fit_predict(X)

--- a/interlock_ml/embedding.py
+++ b/interlock_ml/embedding.py
@@ -19,6 +19,7 @@ class TfidfEmbedder(Embedder):
 
     def __init__(self, **vectorizer_kwargs):
         from sklearn.feature_extraction.text import TfidfVectorizer
+
         self.vectorizer = TfidfVectorizer(**vectorizer_kwargs)
 
     def embed(self, texts: List[str]) -> np.ndarray:
@@ -28,11 +29,76 @@ class TfidfEmbedder(Embedder):
 class BertEmbedder(Embedder):
     """Embed texts using a sentence-transformers BERT model."""
 
-    def __init__(self, model_name: str = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2", batch_size: int = 32, device: str | None = None):
+    def __init__(
+        self,
+        model_name: str = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
+        batch_size: int = 32,
+        device: str | None = None,
+    ):
         from sentence_transformers import SentenceTransformer
+
         self.model = SentenceTransformer(model_name, device=device)
         self.batch_size = batch_size
 
     def embed(self, texts: List[str]) -> np.ndarray:
-        embeddings = self.model.encode(texts, batch_size=self.batch_size, show_progress_bar=False)
+        embeddings = self.model.encode(
+            texts, batch_size=self.batch_size, show_progress_bar=False
+        )
         return np.asarray(embeddings)
+
+
+class TransformerEmbedder(Embedder):
+    """Embed texts using a HuggingFace transformer model."""
+
+    def __init__(
+        self, model_name: str, batch_size: int = 32, device: str | None = None
+    ):
+        from transformers import AutoModel, AutoTokenizer
+        import torch
+
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.model = AutoModel.from_pretrained(model_name)
+        self.batch_size = batch_size
+
+        if device:
+            self.model.to(device)
+            self.device = device
+        else:
+            self.device = next(self.model.parameters()).device
+
+        self.model.eval()
+
+    def embed(self, texts: List[str]) -> np.ndarray:
+        import torch
+
+        embeddings = []
+        with torch.no_grad():
+            for i in range(0, len(texts), self.batch_size):
+                batch = texts[i : i + self.batch_size]
+                encoded = self.tokenizer(
+                    batch, padding=True, truncation=True, return_tensors="pt"
+                ).to(self.device)
+                output = self.model(**encoded)
+                cls_emb = output.last_hidden_state[:, 0, :]
+                embeddings.append(cls_emb.cpu().numpy())
+        return np.vstack(embeddings)
+
+
+class FastTextEmbedder(Embedder):
+    """Embed texts using a FastText model."""
+
+    def __init__(self, model_path: str, batch_size: int = 32):
+        from gensim.models import FastText
+
+        self.model = FastText.load(model_path)
+        self.batch_size = batch_size
+
+    def _embed_sentence(self, sentence: str) -> np.ndarray:
+        words = [self.model.wv[w] for w in sentence.split() if w in self.model.wv]
+        if words:
+            return np.mean(words, axis=0)
+        return np.zeros(self.model.vector_size)
+
+    def embed(self, texts: List[str]) -> np.ndarray:
+        embeddings = [self._embed_sentence(text) for text in texts]
+        return np.vstack(embeddings)

--- a/interlock_ml/factory.py
+++ b/interlock_ml/factory.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Type
+
+from .embedding import Embedder
+from .clustering import Clusterer
+
+
+class EmbedderFactory:
+    """Factory for creating embedders."""
+
+    _registry: Dict[str, Type[Embedder]] = {}
+
+    @classmethod
+    def register(cls, name: str, embedder_cls: Type[Embedder]) -> None:
+        cls._registry[name] = embedder_cls
+
+    @classmethod
+    def create(cls, name: str, **kwargs: Any) -> Embedder:
+        if name not in cls._registry:
+            raise ValueError(f"Unknown embedder '{name}'")
+        return cls._registry[name](**kwargs)
+
+
+class ClustererFactory:
+    """Factory for creating clusterers."""
+
+    _registry: Dict[str, Type[Clusterer]] = {}
+
+    @classmethod
+    def register(cls, name: str, clusterer_cls: Type[Clusterer]) -> None:
+        cls._registry[name] = clusterer_cls
+
+    @classmethod
+    def create(cls, name: str, **kwargs: Any) -> Clusterer:
+        if name not in cls._registry:
+            raise ValueError(f"Unknown clusterer '{name}'")
+        return cls._registry[name](**kwargs)

--- a/interlock_ml/hp_search.py
+++ b/interlock_ml/hp_search.py
@@ -6,9 +6,12 @@ from typing import Dict, Iterable, Tuple, Type
 import numpy as np
 
 from .clustering import Clusterer
+from .embedding import Embedder
 
 
-def search_best_clusterer(clusterer_cls: Type[Clusterer], param_grid: Dict[str, Iterable], X: np.ndarray) -> Tuple[Dict[str, Iterable], float]:
+def search_best_clusterer(
+    clusterer_cls: Type[Clusterer], param_grid: Dict[str, Iterable], X: np.ndarray
+) -> Tuple[Dict[str, Iterable], float]:
     """Simple hyperparameter search using silhouette score."""
     best_score = -1.0
     best_params: Dict[str, Iterable] | None = None
@@ -23,3 +26,34 @@ def search_best_clusterer(clusterer_cls: Type[Clusterer], param_grid: Dict[str, 
             best_score = score
             best_params = params
     return best_params or {}, best_score
+
+
+def search_best_pipeline(
+    embedder_cls: Type[Embedder],
+    clusterer_cls: Type[Clusterer],
+    embedder_grid: Dict[str, Iterable],
+    clusterer_grid: Dict[str, Iterable],
+    texts: Iterable[str],
+) -> Tuple[Dict[str, Iterable], Dict[str, Iterable], float]:
+    """Search for the best combination of embedder and clusterer params."""
+
+    best_score = -1.0
+    best_embedder_params: Dict[str, Iterable] | None = None
+    best_clusterer_params: Dict[str, Iterable] | None = None
+
+    for e_params in ParameterGrid(embedder_grid):
+        embedder = embedder_cls(**e_params)
+        X = embedder.embed(list(texts))
+        for c_params in ParameterGrid(clusterer_grid):
+            clusterer = clusterer_cls(**c_params)
+            labels = clusterer.fit_predict(X)
+            if len(set(labels)) <= 1:
+                score = -1.0
+            else:
+                score = silhouette_score(X, labels)
+            if score > best_score:
+                best_score = score
+                best_embedder_params = e_params
+                best_clusterer_params = c_params
+
+    return (best_embedder_params or {}, best_clusterer_params or {}, best_score)

--- a/interlock_ml/pipeline.py
+++ b/interlock_ml/pipeline.py
@@ -10,7 +10,14 @@ from .clustering import Clusterer
 class EmbeddingClusteringPipeline:
     """Combine embedding and clustering strategies into a single pipeline."""
 
-    def __init__(self, embedder_cls: Type[Embedder], clusterer_cls: Type[Clusterer], *, embedder_kwargs: Dict[str, Any] | None = None, clusterer_kwargs: Dict[str, Any] | None = None):
+    def __init__(
+        self,
+        embedder_cls: Type[Embedder],
+        clusterer_cls: Type[Clusterer],
+        *,
+        embedder_kwargs: Dict[str, Any] | None = None,
+        clusterer_kwargs: Dict[str, Any] | None = None,
+    ):
         self.embedder = embedder_cls(**(embedder_kwargs or {}))
         self.clusterer = clusterer_cls(**(clusterer_kwargs or {}))
 


### PR DESCRIPTION
## Summary
- extend embedding strategy with generic transformer and FastText options
- add several new clustering algorithms
- provide factories to register embedding and clustering backends
- support joint hyperparameter search across pipeline components
- format existing modules with Black

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847815576848322aa8d08d3a73acc1f